### PR TITLE
Install pyroute2 in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,5 +20,6 @@ Vagrant.configure('2') do |config|
   config.vm.provision :shell, :privileged => true, :path => "setup-kernel.sh"
   config.vm.provision :reload
   config.vm.provision :shell, :privileged => true, :path => "setup-bcc.sh"
+  config.vm.provision :shell, :privileged => true, :path => "setup-xdp-script.sh"
 end
 

--- a/setup-xdp-script.sh
+++ b/setup-xdp-script.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ "$USER" != "root" ]]; then
+  echo "script must run as root"
+  exit 1
+fi
+
+set -eux
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get install -y python-pip
+pip install pyroute2


### PR DESCRIPTION
This additional provisioning script for the Vagrantfile installs the necessary requirements for executing the XDP example script suggested in the README: `/usr/share/bcc/examples/networking/xdp/xdp_drop_count.py`.