### PR TITLE
Install required package for add-apt-repository

### DIFF
--- a/setup-apt.sh
+++ b/setup-apt.sh
@@ -13,6 +13,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D4284CDD
 echo "deb [trusted=yes] http://52.8.15.63/apt trusty kernel" | tee /etc/apt/sources.list.d/iovisor.list
 echo "deb [trusted=yes] http://52.8.15.63/apt/trusty trusty-nightly main" | tee -a /etc/apt/sources.list.d/iovisor.list
 
+apt-get install -y software-properties-common
 add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
 
 apt-get update


### PR DESCRIPTION
This pull request installs the `software-properties-common` package as part of the installation. Without this package, I get the following error: `default: /tmp/vagrant-shell: line 16: add-apt-repository: command not found`. I'm surprised this worked before :/