### PR TITLE
Add virtualbox provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,15 @@ Vagrant.configure('2') do |config|
     libvirt.nic_model_type = "e1000"
   end
 
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = 2048
+    vb.cpus = 2
+    vb.customize ["modifyvm", :id, "--ioapic", "on"]
+    vb.customize ["setextradata", :id, "VBoxInternal/CPUM/SSE4.1", "1"]
+    vb.customize ["setextradata", :id, "VBoxInternal/CPUM/SSE4.2", "1"]
+    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  end
+
   config.vm.provision :shell, :privileged => true, :path => "setup-apt.sh"
   config.vm.provision :shell, :privileged => true, :path => "setup-kernel.sh"
   config.vm.provision :reload


### PR DESCRIPTION
Tested in Mac with virtualbox 5.0.26r108824 and Vagrant 1.8.7.

The interface in the host is
```
 vboxnet15: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	ether 0a:00:27:00:00:0f
	inet 192.168.50.1 netmask 0xffffff00 broadcast 192.168.50.255
```

I tested the drops with `sudo ping -f 192.168.50.4` because mac hasn't pktgen, and you can see the results:

```
17: 0 pkt/s
1: 86 pkt/s
17: 0 pkt/s
1: 88 pkt/s
17: 0 pkt/s
1: 85 pkt/s
17: 0 pkt/s
1: 87 pkt/s
17: 1 pkt/s
0: 1 pkt/s
1: 86 pkt/s
```