### PR TITLE
Change from the static address to URL

### DIFF
--- a/setup-apt.sh
+++ b/setup-apt.sh
@@ -10,8 +10,8 @@ set -eux
 export DEBIAN_FRONTEND=noninteractive
 
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D4284CDD
-echo "deb [trusted=yes] http://52.8.15.63/apt trusty kernel" | tee /etc/apt/sources.list.d/iovisor.list
-echo "deb [trusted=yes] http://52.8.15.63/apt/trusty trusty-nightly main" | tee -a /etc/apt/sources.list.d/iovisor.list
+echo "deb [trusted=yes] https://repo.iovisor.org/apt trusty kernel" | tee /etc/apt/sources.list.d/iovisor.list
+echo "deb [trusted=yes] https://repo.iovisor.org/apt/trusty trusty-nightly main" | tee -a /etc/apt/sources.list.d/iovisor.list
 
 apt-get install -y software-properties-common
 add-apt-repository -y ppa:ubuntu-lxc/lxd-stable


### PR DESCRIPTION
Hi,

I'm trying to setup XDP with vagrant by running the script. It is failing to fetch package list from repository server hosted on 52.8.15.63. So I found the same issue at the #6 posted by harsha176.

And then I change from the static IP (52.8.15.63) to URL (https://repo.iovisor.org). I tested setup-apt.sh file. It work properly.