### PR TITLE
Fix up deprecated lxd installation via ppa.

### DIFF
--- a/setup-apt.sh
+++ b/setup-apt.sh
@@ -13,8 +13,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D4284CDD
 echo "deb [trusted=yes] https://repo.iovisor.org/apt trusty kernel" | tee /etc/apt/sources.list.d/iovisor.list
 echo "deb [trusted=yes] https://repo.iovisor.org/apt/trusty trusty-nightly main" | tee -a /etc/apt/sources.list.d/iovisor.list
 
-apt-get install -y software-properties-common
-add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
+apt-get install -y software-properties-common -t trusty-backports lxd lxd-client
 
 apt-get update
 apt-get upgrade -y


### PR DESCRIPTION
The PPA had been deprecated on lxd installation.
Reference issue here: https://github.com/lxc/lxd/issues/4176